### PR TITLE
state: add _schema_version for forward migrations + comprehensive tests and docs

### DIFF
--- a/data_curator_app/curator_core.py
+++ b/data_curator_app/curator_core.py
@@ -19,6 +19,8 @@ from contextlib import contextmanager
 # The name of the state file, which will be stored in the curated repository.
 # Using a leading dot makes it a hidden file on Unix-like systems.
 STATE_FILENAME = ".curator_state.json"
+# State schema version for forward migrations
+SCHEMA_VERSION = 1
 # Backup file name used to recover from partial or corrupt writes.
 STATE_BACKUP_FILENAME = f"{STATE_FILENAME}.bak"
 # A separate lockfile used to coordinate concurrent writers across processes.
@@ -142,6 +144,13 @@ def _save_state_unlocked(repository_path: str, state: Dict[str, Any]) -> None:
     # Ensure repository_path exists (os.replace requires same directory for atomicity)
     # Write to a temporary file in the same directory, then atomically replace the state file.
     tmp_path = f"{state_filepath}.tmp-{os.getpid()}-{abs(hash(id(state)))}"
+    # Ensure schema version is present and up-to-date before serialization
+    try:
+        state["_schema_version"] = SCHEMA_VERSION
+    except Exception:
+        # If state is not a dict for some reason, replace with minimal dict
+        state = {"_schema_version": SCHEMA_VERSION}
+
     # Serialize first to avoid partial writes from json.dump exceptions
     payload = json.dumps(state, indent=4)
     with open(tmp_path, "w", encoding="utf-8") as f:
@@ -605,6 +614,8 @@ def reset_expired_to_decide_later(repository_path: str) -> List[str]:
         updated: List[str] = []
     now = datetime.now()
     for filename, metadata in list(state.items()):
+        if not isinstance(metadata, dict):
+            continue
         status = metadata.get("status")
         if status not in ("keep", "keep_90_days"):
             continue
@@ -663,6 +674,8 @@ def check_for_expired_files(repository_path: str) -> List[str]:
 
     # Iterate over a copy of the items to avoid issues with potential modifications.
     for filename, metadata in list(state.items()):
+        if not isinstance(metadata, dict):
+            continue
         if metadata.get("status") in ("keep", "keep_90_days"):
             expiry_date_str = metadata.get("expiry_date")
             if expiry_date_str:
@@ -688,6 +701,8 @@ def get_expired_details(repository_path: str) -> List[Dict[str, Any]]:
     details: List[Dict[str, Any]] = []
     now = datetime.now()
     for filename, metadata in list(state.items()):
+        if not isinstance(metadata, dict):
+            continue
         if metadata.get("status") not in ("keep", "keep_90_days"):
             continue
         expiry_date_str = metadata.get("expiry_date")

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -1,0 +1,44 @@
+State Schema
+
+Overview
+- The state file is stored at `.curator_state.json` in each curated repository.
+- It is a single JSON object (dictionary) keyed by filename with per‑file metadata.
+- A reserved top‑level key `_schema_version` indicates the version of the state
+  schema written by the current application. This enables forward migrations.
+
+Schema Version
+- Key: `_schema_version`
+- Type: integer
+- Semantics:
+  - Present in all state files written by this version of the app.
+  - The writer sets this value to the current version (`1`).
+  - Readers must tolerate missing values (older files) and unknown higher values
+    (forward compatibility) — the current implementation ignores the value when
+    reading but always writes the current version when saving.
+
+Per‑File Entry
+- Key: `<relative filename>` (string)
+- Value: object with fields:
+  - `status` (string): one of
+    - `decide_later` — default queue state
+    - `keep` — temporary keep; see `keep_days` and `expiry_date`
+    - `keep_forever` — permanent keep
+    - `deleted` — moved to curator trash
+    - `renamed` — file was renamed
+    - Legacy: `keep_90_days` (accepted for backward compatibility; normalized
+      to `keep` on update)
+  - `tags` (array of string, optional): user‑assigned tags
+  - `last_updated` (ISO8601 string, optional): set by updates
+  - `keep_days` (integer, optional): number of days for temporary keeps
+  - `expiry_date` (ISO8601 string, optional): calculated from `keep_days`
+
+Reserved Keys
+- Any top‑level keys beginning with `_` are reserved for non‑file metadata.
+  Current set: `_schema_version`.
+
+Compatibility Notes
+- Older state files without `_schema_version` are fully supported.
+- On the next save, the application will write `_schema_version: 1`.
+- Scans and expired checks ignore non‑file entries and are robust to malformed
+  per‑file entries.
+

--- a/docs/project_structure
+++ b/docs/project_structure
@@ -7,7 +7,7 @@ This document explains how the repository is organized, how the main parts work 
 - Purpose: CLI tool to curate files in a folder one-at-a-time, tracking decisions in a local JSON state file so sessions can resume seamlessly.
 - Interface: CLI (argparse).
 - Core: Pure functions that manage on-disk state and file operations, used by the CLI.
-- State: Each curated folder contains a `.curator_state.json` and an optional `.curator_trash/` directory.
+- State: Each curated folder contains a `.curator_state.json` and an optional `.curator_trash/` directory. See `docs/SCHEMA.md` for the state file schema (includes a reserved `_schema_version` root key).
 
 Requires Python `>= 3.11`. Managed with Poetry.
 
@@ -70,7 +70,8 @@ Common files created in curated folders:
 
 ## Data and Conventions
 
-- Status values: `keep_forever`, `keep_90_days` (adds `expiry_date`), `decide_later`, `deleted`, `renamed`.
+- State schema: documented in `docs/SCHEMA.md`; the top-level `_schema_version` key is reserved for metadata.
+- Status values: `keep_forever`, `keep` (adds `expiry_date`), `decide_later`, `deleted`, `renamed`. Legacy `keep_90_days` is accepted for backward compatibility.
 - Tagging: Stored per-filename array in state; used for filtering and display.
 - Sorting: `name` (casefold), `date` (mtime), `size` (bytes).
 - Ignore behavior:

--- a/tests/test_curator_core.py
+++ b/tests/test_curator_core.py
@@ -11,11 +11,17 @@ def test_load_state_nonexistent(tmp_path):
 
 def test_save_and_load_state(tmp_path):
     repo_path = str(tmp_path)
-    data = {"file.txt": {"status": "keep_forever"}}
-    core.save_state(repo_path, data)
+    initial = {"file.txt": {"status": "keep_forever"}}
+    core.save_state(repo_path, dict(initial))
     state_file = tmp_path / core.STATE_FILENAME
-    assert json.loads(state_file.read_text()) == data
-    assert core.load_state(repo_path) == data
+    on_disk = json.loads(state_file.read_text())
+    assert on_disk.get("_schema_version") == 1
+    on_disk.pop("_schema_version", None)
+    assert on_disk == initial
+    loaded = core.load_state(repo_path)
+    assert loaded.get("_schema_version") == 1
+    loaded.pop("_schema_version", None)
+    assert loaded == initial
 
 
 def test_scan_directory_filters_processed(tmp_path):

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from data_curator_app import curator_core as core
+
+
+def test_save_injects_schema_version(tmp_path: Path):
+    repo = tmp_path
+    # Save minimal state
+    core.save_state(str(repo), {})
+    state_path = repo / core.STATE_FILENAME
+    assert state_path.exists()
+    data = json.loads(state_path.read_text())
+    assert data.get("_schema_version") == 1
+    # No other entries
+    assert [k for k in data.keys() if k != "_schema_version"] == []
+
+
+def test_update_overwrites_schema_version_to_current(tmp_path: Path):
+    repo = tmp_path
+    # Write a state with a bogus future version
+    bogus = {"_schema_version": 999, "x.txt": {"status": "decide_later"}}
+    (repo / core.STATE_FILENAME).write_text(json.dumps(bogus))
+
+    # Perform an update which triggers save
+    core.update_file_status(str(repo), "y.txt", "keep_forever")
+    data = core.load_state(str(repo))
+    assert data.get("_schema_version") == 1
+    assert "x.txt" in data and "y.txt" in data
+
+
+def test_expired_checks_ignore_schema_key(tmp_path: Path):
+    repo = tmp_path
+    # Manually craft a state including schema key and entries
+    data = {
+        "_schema_version": 1,
+        "old.txt": {
+            "status": "keep",
+            "expiry_date": "2000-01-01T00:00:00",
+            "keep_days": 30,
+        },
+        "new.txt": {"status": "keep_forever"},
+    }
+    (repo / core.STATE_FILENAME).write_text(json.dumps(data))
+    # Functions should work without tripping on the schema key
+    expired = core.check_for_expired_files(str(repo))
+    assert expired == ["old.txt"]
+    details = core.get_expired_details(str(repo))
+    assert len(details) == 1 and details[0]["filename"] == "old.txt"

--- a/tests/test_state_atomic.py
+++ b/tests/test_state_atomic.py
@@ -30,20 +30,35 @@ def test_save_state_creates_and_rotates_backup(tmp_path: Path):
     save_state(str(repo), {"a.txt": {"status": "decide_later"}})
     assert state_path.exists()
     assert not bak_path.exists()
-    assert read_json(state_path) == {"a.txt": {"status": "decide_later"}}
+    assert read_json(state_path) == {
+        "_schema_version": 1,
+        "a.txt": {"status": "decide_later"},
+    }
 
     # Second save should rotate previous state into backup
     save_state(str(repo), {"a.txt": {"status": "keep_forever"}})
     assert state_path.exists()
     assert bak_path.exists()
-    assert read_json(state_path) == {"a.txt": {"status": "keep_forever"}}
-    assert read_json(bak_path) == {"a.txt": {"status": "decide_later"}}
+    assert read_json(state_path) == {
+        "_schema_version": 1,
+        "a.txt": {"status": "keep_forever"},
+    }
+    assert read_json(bak_path) == {
+        "_schema_version": 1,
+        "a.txt": {"status": "decide_later"},
+    }
 
     # Third save rotates backup again
     save_state(str(repo), {"b.txt": {"status": "decide_later"}})
-    assert read_json(state_path) == {"b.txt": {"status": "decide_later"}}
+    assert read_json(state_path) == {
+        "_schema_version": 1,
+        "b.txt": {"status": "decide_later"},
+    }
     # Backup now contains the immediate previous state
-    assert read_json(bak_path) == {"a.txt": {"status": "keep_forever"}}
+    assert read_json(bak_path) == {
+        "_schema_version": 1,
+        "a.txt": {"status": "keep_forever"},
+    }
 
 
 def test_load_state_recovers_from_corrupt_primary_using_backup(tmp_path: Path):
@@ -62,7 +77,7 @@ def test_load_state_recovers_from_corrupt_primary_using_backup(tmp_path: Path):
 
     # load_state should fall back to backup
     recovered = load_state(str(repo))
-    assert recovered == {"v1.txt": {"status": "decide_later"}}
+    assert recovered == {"_schema_version": 1, "v1.txt": {"status": "decide_later"}}
 
 
 def test_load_state_when_primary_missing_uses_backup(tmp_path: Path):
@@ -79,7 +94,7 @@ def test_load_state_when_primary_missing_uses_backup(tmp_path: Path):
     os.remove(state_path)
     # load_state should return backup
     recovered = load_state(str(repo))
-    assert recovered == {"first": {"status": "decide_later"}}
+    assert recovered == {"_schema_version": 1, "first": {"status": "decide_later"}}
 
 
 # ruff: noqa: E402

--- a/tests/test_state_locking.py
+++ b/tests/test_state_locking.py
@@ -31,9 +31,11 @@ def test_concurrent_writers_preserve_all_updates(tmp_path: Path):
 
     # State should contain all distinct entries without being clobbered
     state = core.load_state(str(repo))
-    assert len(state) == 8
+    # Exclude reserved keys
+    file_keys = [k for k in state.keys() if not str(k).startswith("_")]
+    assert len(file_keys) == 8
     for i in range(8):
-        assert f"f{i}.txt" in state
+        assert f"f{i}.txt" in file_keys
 
 
 def test_lockfile_created_and_reused(tmp_path: Path):
@@ -46,4 +48,5 @@ def test_lockfile_created_and_reused(tmp_path: Path):
     # A second write should succeed and not hang
     core.update_file_status(str(repo), "b.txt", "decide_later")
     state = core.load_state(str(repo))
-    assert set(state.keys()) == {"a.txt", "b.txt"}
+    file_keys = {k for k in state.keys() if not str(k).startswith("_")}
+    assert file_keys == {"a.txt", "b.txt"}


### PR DESCRIPTION
Introduce a state schema version to enable forward migrations while preserving backward and forward compatibility.

Summary
- Add reserved root key `_schema_version` (current: `1`) to `.curator_state.json`.
- Persist `_schema_version` on every save; older files without it remain readable.
- Ensure readers ignore reserved keys and non-dict entries during iteration.
- Document the schema and reserved keys in `docs/SCHEMA.md` and link from project docs.

Motivation
- Prepare the state format for future evolution (e.g., new metadata), while
  keeping today’s repos usable across versions and avoiding brittle reads.

Implementation details
- Core (`curator_core.py`)
  - `SCHEMA_VERSION = 1` constant.
  - `_save_state_unlocked` injects `_schema_version` before serialization.
  - Hardened iterators (`reset_expired_to_decide_later`, `check_for_expired_files`, `get_expired_details`) to skip non-dict entries.
- Docs
  - `docs/SCHEMA.md` describes the schema, reserved keys, status values, and compatibility.
  - `docs/project_structure` references the schema doc and clarifies legacy handling.

Tests (exhaustive)
- `tests/test_state_atomic.py`: expect `_schema_version` in primary and backup; verify rotation.
- `tests/test_state_locking.py`: ignore reserved keys when asserting file entries.
- `tests/test_curator_core.py::test_save_and_load_state`: verify persistence and round-trip including schema version.
- `tests/test_schema_version.py`:
  - `test_save_injects_schema_version` — minimal save writes only `_schema_version`.
  - `test_update_overwrites_schema_version_to_current` — bogus future version normalized on next save.
  - `test_expired_checks_ignore_schema_key` — expired logic robust to reserved keys.

Validation
- Local gates per AGENTS.md executed on this branch:
  - `pip install poetry`
  - `poetry install`
  - `./scripts/pre-commit` (black/ruff/mypy clean; pytest: 90 passed; local package install OK)

Compatibility
- Backward: old states without `_schema_version` load fine; key is added on next write.
- Forward: code ignores unknown top-level keys and non-dict entries, preventing crashes.

