### PR TITLE
Validate status values with custom CLI errors; enforce in core; add tests

### DIFF
--- a/data_curator_app/cli.py
+++ b/data_curator_app/cli.py
@@ -166,10 +166,7 @@ def handle_set_status(
     # Validate status against allowed user set (include legacy alias)
     allowed_user = set(core.USER_ALLOWED_STATUSES) | {"keep_90_days"}
     if status not in allowed_user:
-        msg = (
-            f"Invalid status '{status}'. Allowed: "
-            + ", ".join(sorted(allowed_user))
-        )
+        msg = f"Invalid status '{status}'. Allowed: " + ", ".join(sorted(allowed_user))
         if json_output:
             print(json.dumps({"error": msg, "code": 3}))
         else:
@@ -1054,10 +1051,7 @@ def handle_status_batch(
     # Validate status against allowed user set (include legacy alias)
     allowed_user = set(core.USER_ALLOWED_STATUSES) | {"keep_90_days"}
     if status not in allowed_user:
-        msg = (
-            f"Invalid status '{status}'. Allowed: "
-            + ", ".join(sorted(allowed_user))
-        )
+        msg = f"Invalid status '{status}'. Allowed: " + ", ".join(sorted(allowed_user))
         if json_output:
             print(json.dumps({"error": msg, "code": 3}))
         else:
@@ -1085,9 +1079,7 @@ def handle_status_batch(
             with contextlib.redirect_stdout(io.StringIO()):
                 core.update_file_status(repository_path, filename, status, days=days)
         except ValueError as e:
-            results.append(
-                {"filename": filename, "error": str(e), "code": 3}
-            )
+            results.append({"filename": filename, "error": str(e), "code": 3})
             failed += 1
             continue
         entry: dict[str, Any] = {

--- a/docs/developer_diary.md
+++ b/docs/developer_diary.md
@@ -53,7 +53,7 @@
   - [ ] Add examples for every subcommand in `argparse` epilog.
   - [ ] Provide shell completion stubs (bash/zsh/fish) via `argcomplete` or static generation.
 
-- [ ] Validate `status` values against an allowed set; reject unknown values with exit code 3 and JSON error.
+- [x] Validate `status` values against an allowed set; reject unknown values with exit code 3 and JSON error.
 - [ ] Add `open`/`reveal` command to expose `open_file_location()` for convenience.
 - [ ] Add trash management: `trash list`, `trash prune --older N`, and `restore --all` commands.
 - [ ] Add `list --status <status>` to list curated items (not just pending) and support status filtering.

--- a/tests/test_cli_status_validation.py
+++ b/tests/test_cli_status_validation.py
@@ -14,9 +14,7 @@ def test_status_invalid_rejected_json(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "a.txt").write_text("a")
-    res = run_cli(
-        str(repo), ["status", "a.txt", "not_a_status", "--json"]
-    )
+    res = run_cli(str(repo), ["status", "a.txt", "not_a_status", "--json"])
     assert res.returncode == 3
     data = json.loads(res.stdout)
     assert data["code"] == 3 and "Invalid status" in data["error"]
@@ -26,9 +24,7 @@ def test_status_invalid_rejected_non_json(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "a.txt").write_text("a")
-    res = run_cli(
-        str(repo), ["status", "a.txt", "not_a_status"]
-    )
+    res = run_cli(str(repo), ["status", "a.txt", "not_a_status"])
     assert res.returncode == 3
     assert res.stdout.strip().startswith("Error:")
 
@@ -69,4 +65,3 @@ def test_status_batch_invalid_rejected_non_json(tmp_path: Path):
     )
     assert res.returncode == 3
     assert res.stdout.strip().startswith("Error:")
-

--- a/tests/test_cli_status_validation.py
+++ b/tests/test_cli_status_validation.py
@@ -1,0 +1,72 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def run_cli(repo_path: str, args: list[str]) -> subprocess.CompletedProcess:
+    cmd = ["python", "-m", "data_curator_app.cli", repo_path] + args
+    return subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+
+
+def test_status_invalid_rejected_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.txt").write_text("a")
+    res = run_cli(
+        str(repo), ["status", "a.txt", "not_a_status", "--json"]
+    )
+    assert res.returncode == 3
+    data = json.loads(res.stdout)
+    assert data["code"] == 3 and "Invalid status" in data["error"]
+
+
+def test_status_invalid_rejected_non_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.txt").write_text("a")
+    res = run_cli(
+        str(repo), ["status", "a.txt", "not_a_status"]
+    )
+    assert res.returncode == 3
+    assert res.stdout.strip().startswith("Error:")
+
+
+def test_status_batch_invalid_rejected_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.txt").write_text("a")
+    res = run_cli(
+        str(repo),
+        [
+            "status-batch",
+            "--files",
+            "a.txt",
+            "--status",
+            "not_a_status",
+            "--json",
+        ],
+    )
+    assert res.returncode == 3
+    data = json.loads(res.stdout)
+    assert data["code"] == 3 and "Invalid status" in data["error"]
+
+
+def test_status_batch_invalid_rejected_non_json(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.txt").write_text("a")
+    res = run_cli(
+        str(repo),
+        [
+            "status-batch",
+            "--files",
+            "a.txt",
+            "--status",
+            "not_a_status",
+        ],
+    )
+    assert res.returncode == 3
+    assert res.stdout.strip().startswith("Error:")
+


### PR DESCRIPTION
Summary
- Adds explicit validation of status values both at the CLI boundary and in core, returning exit code 3 with structured JSON errors for invalid inputs.

Changes
- CLI
  - Remove argparse `choices` for `status`/`--status` to allow custom validation and JSON error output.
  - Validate user-provided statuses against `USER_ALLOWED_STATUSES` (plus legacy alias `keep_90_days`).
  - On invalid status: print `{"error": ..., "code": 3}` in JSON mode, or a friendly `Error:` line in text mode; exit 3.
  - Propagate core validation failures in both single and batch handlers.
- Core
  - Introduce `USER_ALLOWED_STATUSES`, `_INTERNAL_ONLY_STATUSES`, and `ALLOWED_STATUSES`.
  - Map legacy `keep_90_days` → `keep` with a default of 90 days.
  - Reject unknown statuses in `update_file_status` by raising `ValueError` with a clear message.
- Tests
  - New `tests/test_cli_status_validation.py` covering:
    - `status` invalid value (JSON and non-JSON)
    - `status-batch` invalid value (JSON and non-JSON)
- Docs
  - Check off the developer diary checklist item: “Validate status values … exit code 3 and JSON error.”

Behavior
- Valid statuses remain: `keep_forever`, `keep`, `decide_later` (user); internal statuses `deleted`, `renamed` are preserved in core.
- Legacy `keep_90_days` remains accepted and is mapped to `keep` (deprecation can be added separately with a warning).
- Exit code semantics for invalid status are now consistent: 3 for argument validation errors in these commands.

Why
- Aligns CLI behavior with the diary requirement for structured error handling and consistent exit codes, enabling robust scripting and tooling.

Validation
- 96 tests passing: `pytest -q`
- Lint/Type checks: `ruff check .` and `mypy data_curator_app` pass locally.
- Black formatting applied to touched files.

How to test
- Single file (JSON):
  `python -m data_curator_app.cli /tmp/repo status f.txt not_a_status --json` → exit 3, JSON error.
- Single file (text):
  `python -m data_curator_app.cli /tmp/repo status f.txt not_a_status` → exit 3, human error line.
- Batch (JSON):
  `python -m data_curator_app.cli /tmp/repo status-batch --files f.txt --status not_a_status --json` → exit 3, JSON error.

Notes
- Could not run `poetry install`/`./scripts/pre-commit` in this environment; CI should cover. Locally validated format/lint/types/tests as noted above.
- Happy to add a deprecation warning for `keep_90_days` in a follow-up.
